### PR TITLE
Add FastAPI-based web server for FT-897 control

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# rpt
+# FT-897 Web Control
+
+This repository provides a minimal FastAPI based web server to control a Yaesu
+FT-897 transceiver over its CAT interface.  It exposes a handful of HTTP
+endpoints for connection management, frequency tuning and PTT control and comes
+with a very small HTML frontend.
+
+## Usage
+
+```bash
+uvicorn app:app --reload
+```
+
+Then open [http://localhost:8000](http://localhost:8000) in your browser.  The
+server relies on the `serial` module to talk to the radio; make sure the CAT
+interface is connected and accessible.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,90 @@
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+from pydantic import BaseModel
+
+from ft897cat import FT897CAT
+
+app = FastAPI(title="FT-897 Web Control")
+
+# expose static assets
+app.mount("/static", StaticFiles(directory="static"), name="static")
+
+# template renderer
+templates = Jinja2Templates(directory="templates")
+
+# global CAT instance
+radio = FT897CAT()
+
+
+class ConnectRequest(BaseModel):
+    port: str
+    baudrate: int = 9600
+
+
+class FrequencyRequest(BaseModel):
+    frequency: int
+
+
+@app.get("/", response_class=HTMLResponse)
+async def index(request: Request):
+    freq = radio.get_frequency() if radio.is_connected else None
+    return templates.TemplateResponse(
+        "index.html", {"request": request, "frequency": freq}
+    )
+
+
+@app.post("/connect")
+async def connect(req: ConnectRequest):
+    if radio.connect(req.port, req.baudrate):
+        return {"status": "connected"}
+    raise HTTPException(status_code=400, detail=radio.last_error or "Failed to connect")
+
+
+@app.post("/disconnect")
+async def disconnect():
+    radio.disconnect()
+    return {"status": "disconnected"}
+
+
+@app.get("/status")
+async def status():
+    if not radio.is_connected:
+        raise HTTPException(400, detail="Radio not connected")
+    freq = radio.get_frequency()
+    sm = radio.get_smeter()
+    tx = radio.read_tx_status()
+    return {"frequency": freq, "smeter": sm, "tx_status": tx}
+
+
+@app.get("/frequency")
+async def get_frequency():
+    freq = radio.get_frequency()
+    if freq is None:
+        raise HTTPException(400, detail="Radio not connected")
+    return {"frequency": freq}
+
+
+@app.post("/frequency")
+async def set_frequency(req: FrequencyRequest):
+    if radio.set_frequency(req.frequency):
+        return {"status": "ok"}
+    raise HTTPException(400, detail="Failed to set frequency")
+
+
+@app.post("/ptt/on")
+async def ptt_on():
+    if radio.ptt_on():
+        return {"status": "tx"}
+    raise HTTPException(400, detail="PTT failed")
+
+
+@app.post("/ptt/off")
+async def ptt_off():
+    if radio.ptt_off():
+        return {"status": "rx"}
+    raise HTTPException(400, detail="PTT failed")
+
+
+# Convenience: run with `uvicorn app:app --reload`

--- a/ft897cat.py
+++ b/ft897cat.py
@@ -1,0 +1,189 @@
+import serial
+import time
+import threading
+
+
+class FT897CAT:
+    """Simple CAT control for the Yaesu FT-897 transceiver.
+
+    Only a subset of the original desktop application's functionality is
+    implemented here.  It is enough for frequency control, reading status and
+    basic PTT handling which are exposed through the FastAPI web server.
+    """
+
+    MODE_MAP = {
+        "LSB": 0x00,
+        "USB": 0x01,
+        "CW": 0x02,
+        "CWR": 0x03,
+        "AM": 0x04,
+        "FM": 0x08,
+        "DIG": 0x0A,
+        "PKT": 0x0C,
+    }
+
+    def __init__(self):
+        self.port = None
+        self.baudrate = 9600
+        self.is_connected = False
+        self.serial_port = None
+        self._lock = threading.Lock()
+        self.last_error = None
+
+    # ---- low level helpers -------------------------------------------------
+    def _send(self, data: bytes) -> bool:
+        """Send raw CAT command bytes to the radio."""
+        with self._lock:
+            try:
+                self.serial_port.reset_input_buffer()
+                self.serial_port.reset_output_buffer()
+                self.serial_port.write(data)
+                self.serial_port.flush()
+                time.sleep(0.05)
+                return True
+            except Exception as e:  # pragma: no cover - serial errors
+                self.last_error = f"Write failed: {e}"
+                return False
+
+    def _read(self, length: int = 5) -> bytes | None:
+        with self._lock:
+            try:
+                return self.serial_port.read(length)
+            except Exception as e:  # pragma: no cover - serial errors
+                self.last_error = f"Read failed: {e}"
+                return None
+
+    def _handshake(self) -> bool:
+        try:
+            if not self._send(b"\x00\x00\x00\x00\x03"):
+                return False
+            time.sleep(0.12)
+            resp = self._read(5)
+            if not resp or len(resp) != 5:
+                self.last_error = "No CAT response (freq read)"
+                return False
+            return True
+        except Exception as e:  # pragma: no cover - serial errors
+            self.last_error = f"Handshake failed: {e}"
+            return False
+
+    # ---- connection --------------------------------------------------------
+    def connect(self, port: str, baudrate: int = 9600) -> bool:
+        self.port = port
+        self.baudrate = baudrate
+        self.last_error = None
+        try:
+            self.serial_port = serial.Serial(
+                port=port,
+                baudrate=baudrate,
+                bytesize=serial.EIGHTBITS,
+                parity=serial.PARITY_NONE,
+                stopbits=serial.STOPBITS_ONE,
+                timeout=0.3,
+                write_timeout=0.3,
+                xonxoff=False,
+                rtscts=False,
+                dsrdtr=False,
+            )
+            try:
+                self.serial_port.setDTR(True)
+                self.serial_port.setRTS(True)
+            except Exception:
+                pass
+            time.sleep(0.20)
+            if not self._handshake():
+                try:
+                    self.serial_port.close()
+                except Exception:
+                    pass
+            else:
+                self.is_connected = True
+                return True
+        except PermissionError:
+            self.last_error = "Permission denied to open port"
+        except serial.SerialException as e:
+            self.last_error = f"Serial exception: {e}"
+        except Exception as e:  # pragma: no cover
+            self.last_error = f"Open failed: {e}"
+        self.is_connected = False
+        return False
+
+    def disconnect(self) -> None:
+        if self.serial_port and self.serial_port.is_open:
+            try:
+                self.serial_port.close()
+            except Exception:
+                pass
+        self.is_connected = False
+
+    # ---- basic status ------------------------------------------------------
+    def get_frequency(self) -> int | None:
+        if not self.is_connected:
+            return None
+        if not self._send(b"\x00\x00\x00\x00\x03"):
+            return None
+        resp = self._read(5)
+        if not resp or len(resp) != 5:
+            return None
+        units_10hz = 0
+        for b in resp[:4]:
+            units_10hz = units_10hz * 100 + ((b >> 4) & 0x0F) * 10 + (b & 0x0F)
+        return units_10hz * 10
+
+    def get_smeter(self) -> int | None:
+        if not self.is_connected:
+            return None
+        with self._lock:
+            try:
+                self.serial_port.reset_input_buffer()
+                self.serial_port.reset_output_buffer()
+                self.serial_port.write(b"\x00\x00\x00\x00\xe7")
+                time.sleep(0.1)
+                resp = self.serial_port.read(1)
+            except Exception:  # pragma: no cover - serial errors
+                return None
+        if not resp:
+            return None
+        return resp[0] & 0x0F
+
+    def read_tx_status(self) -> int | None:
+        if not self.is_connected:
+            return None
+        if not self._send(b"\x00\x00\x00\x00\xf7"):
+            return None
+        resp = self._read(1)
+        if not resp:
+            return None
+        return resp[0]
+
+    # ---- PTT ----------------------------------------------------------------
+    def ptt_on(self) -> bool:
+        if not self.is_connected:
+            return False
+        return self._send(b"\x00\x00\x00\x00\x08")
+
+    def ptt_off(self) -> bool:
+        if not self.is_connected:
+            return False
+        return self._send(b"\x00\x00\x00\x00\x88")
+
+    # ---- Tuning / mode ------------------------------------------------------
+    def set_frequency(self, freq_hz: int) -> bool:
+        if not self.is_connected:
+            return False
+        units_10hz = int(freq_hz // 10)
+        digits = f"{units_10hz:08d}"
+        bcd = bytearray()
+        for i in range(0, 8, 2):
+            bcd.append((int(digits[i]) << 4) | int(digits[i + 1]))
+        return self._send(bytes(bcd) + b"\x01")
+
+    def set_mode(self, mode: str) -> bool:
+        if not self.is_connected:
+            return False
+        code = self.MODE_MAP.get(mode)
+        if code is None:
+            return False
+        cmd = bytes([code, 0x00, 0x00, 0x00, 0x07])
+        return self._send(cmd)
+

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,2 @@
+body { font-family: sans-serif; margin: 2em; background: #f5f5f5; }
+nav a { margin-right: 1em; }

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>FT-897 Web Control</title>
+  <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+<nav>
+  <a href="/">Frequency</a>
+</nav>
+<main>
+  {% block content %}{% endblock %}
+</main>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>FT-897 Control</h1>
+<p>Current frequency: {{ frequency if frequency else '---' }} Hz</p>
+<form id="freqForm">
+  <input type="number" id="freqInput" placeholder="Frequency in Hz"/>
+  <button type="submit">Set</button>
+</form>
+<button id="pttOn">PTT ON</button>
+<button id="pttOff">PTT OFF</button>
+<script>
+document.getElementById('freqForm').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const freq = parseInt(document.getElementById('freqInput').value);
+  await fetch('/frequency', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({frequency: freq})
+  });
+  window.location.reload();
+});
+
+document.getElementById('pttOn').addEventListener('click', async () => {
+  await fetch('/ptt/on', {method: 'POST'});
+});
+
+document.getElementById('pttOff').addEventListener('click', async () => {
+  await fetch('/ptt/off', {method: 'POST'});
+});
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Introduce `ft897cat.py` with a minimal CAT driver for Yaesu FT-897
- Add FastAPI application exposing frequency, status and PTT endpoints
- Provide simple HTML frontend and styling

## Testing
- `python -m py_compile app.py ft897cat.py`
- `pip install fastapi uvicorn`
- `uvicorn app:app --help`


------
https://chatgpt.com/codex/tasks/task_e_68ab4de607dc832183cb2b90b30aac8a